### PR TITLE
Removed telephone number from the page

### DIFF
--- a/kset/templates/subpage.html
+++ b/kset/templates/subpage.html
@@ -39,13 +39,6 @@
       </tr>
       <tr>
         <td>
-            {# Translators: tel #}
-          <strong>{% trans "telefon-short" %}:</strong>
-        </td>
-        <td>+385 1 6129 758</td>
-      </tr>
-      <tr>
-        <td>
             {# Translators: gdje #}
           <strong>{% trans "location-short" %}?!</strong>
         </td>


### PR DESCRIPTION
By the request of L. Zadro, I removed telephone number from the /club page.
Reason for that is that people are calling and nobody answers.